### PR TITLE
Update data fetching routine to accommodate CDPHE changes

### DIFF
--- a/api/data_api.py
+++ b/api/data_api.py
@@ -30,9 +30,7 @@ def utilities(conn: Connection = Depends(get_db_conn)):
     logger.debug(f"Querying utilities")
     results = db.get_utilities(conn)
     if len(results) == 0:
-        resp = fastapi.Response(
-            content="Internal error. Please try again later.", status_code=500
-        )
+        resp = fastapi.Response(content="Internal error. Please try again later.", status_code=500)
     else:
         resp = {"utilities": results}
     return resp
@@ -42,9 +40,10 @@ def utilities(conn: Connection = Depends(get_db_conn)):
 def samples(report: Report = Depends(), conn: Connection = Depends(get_db_conn)):
     results = db.get_samples(conn, report)
     if len(results) == 0:
-        resp = fastapi.Response(
-            content="Internal error. Please try again later.", status_code=500
-        )
+        resp = fastapi.Response(content="Internal error. Please try again later.", status_code=500)
     else:
         resp = {"parameters": report.dict(), "samples": results}
     return resp
+
+
+# TODO: endpoint for last_checked and last_data_update

--- a/runbook.md
+++ b/runbook.md
@@ -45,6 +45,28 @@ python tools/update_data.py
 
 6. verify [the streamlit app](https://colorado-covid-wastewater.streamlit.app/) reloads correctly
 
+## Walk through `__main__` steps manually
+
+From a fresh ipython repl in the venv
+```python
+from tools.update_data import *
+from sqlite_utils.utils import sqlite3
+from datetime import datetime
+from dateutil import parser
+from pathlib import Path
+
+sqlite3.enable_callback_tracebacks(True)
+latest_local_update = parser.parse('2023-09-09').date()
+latest_portal_update = get_latest_portal_update()
+download = 'data/2023-09-11_download.json'
+raw_data = json.loads(Path(download).read_text())
+xformed_data = transform_raw_data(raw_data)
+database = "data/wastewater.db"
+main_table = "latest"
+db = Database(database)
+db[main_table].insert_all(records=xformed_data)
+```
+
 ## Modify systemd service unit and reboot
 
 If changing the service file:

--- a/services/db.py
+++ b/services/db.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 # DB conventions
 PROD_TABLE = "latest"
 DATE_COL = "Date"
-SAMPLES_COL = "SARS_CoV_2_copies_L"
+SAMPLES_COLS = ["SARS_COV_2_Copies_L_LP1", "SARS_COV_2_Copies_L_LP2"]
 UTILITY_COL = "Utility"
 
 
@@ -28,9 +28,7 @@ def get_connection(db_uri: str) -> sqlite3.Connection:
 def get_utilities(conn: sqlite3.Connection) -> List[str]:
     # CRUD fn for utilities
     query = (
-        f"SELECT DISTINCT {UTILITY_COL} "
-        + f"FROM {PROD_TABLE} "
-        + f"ORDER BY {UTILITY_COL} ASC"
+        f"SELECT DISTINCT {UTILITY_COL} " + f"FROM {PROD_TABLE} " + f"ORDER BY {UTILITY_COL} ASC"
     )
     logger.debug(f"Issuing db query: {query}")
     list_of_utility_lists: List[Tuple[str]] = conn.execute(query).fetchall()
@@ -42,7 +40,7 @@ def get_utilities(conn: sqlite3.Connection) -> List[str]:
 def get_samples(conn: sqlite3.Connection, report: Report = Depends()) -> List[str]:
     # CRUD fn for samples
     # notes on sqlite quoting and keywords: https://www.sqlite.org/lang_keywords.html
-    cols = f"{DATE_COL}, {SAMPLES_COL}"
+    cols = f"{DATE_COL}, {','.join(SAMPLES_COLS)}"
     condition = (
         f"{UTILITY_COL} = '{report.utility}' "
         + f"AND {DATE_COL} >= '{report.start}' "

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -19,8 +19,9 @@ def override_db_conn() -> sqlite3.Connection:
     test_cols = [
         "Date",
         "Utility",
-        "SARS_CoV_2_copies_L",
-        "Number_of_New_COVID19_Cases_by_",
+        "SARS_COV_2_Copies_L_LP1",
+        "SARS_COV_2_Copies_L_LP2",
+        "Cases",
     ]
 
     # the default Report range is dynamically (-30d, today) - ensure that
@@ -28,17 +29,17 @@ def override_db_conn() -> sqlite3.Connection:
     today = date.today().isoformat()
     yesterday = (date.today() - timedelta(days=1)).isoformat()
     test_data = [
-        ("2022-03-16", "Arapahoe County", 1, 0),
-        ("2022-03-17", "Arapahoe County", 3, 0),
-        ("2022-03-19", "Arapahoe County", 5, 0),
-        (yesterday, DEFAULT_UTILITY, 3, 0),
-        (today, DEFAULT_UTILITY, 9, 0),
+        ("2022-03-16", "Arapahoe County", 1, 0, 0),
+        ("2022-03-17", "Arapahoe County", 3, 0, 0),
+        ("2022-03-19", "Arapahoe County", 5, 0, 0),
+        (yesterday, DEFAULT_UTILITY, 3, 0, 0),
+        (today, DEFAULT_UTILITY, 9, 0, 0),
     ]
 
     test_table = "latest"
     table_cols = f"{test_table}({','.join(test_cols)})"
     table_create_stmt = f"CREATE TABLE {table_cols}"
-    insert_stmt = f"INSERT INTO {table_cols} VALUES (?, ?, ?, ?)"
+    insert_stmt = f"INSERT INTO {table_cols} VALUES (?, ?, ?, ?, ?)"
 
     con: sqlite3.Connection = sqlite3.connect(":memory:")
     con.execute(table_create_stmt)


### PR DESCRIPTION
Once again, the health department introduced breaking changes to their open data portal to accommodate "Phase 2" of their reporting strategy.

Fortunately, this project's API doesn't have to make any changes to requests. However, the schema of the data returned has an additional field now (for this "phase 2" data). Assuming that there will no longer be data populated in the "phase 1" fields, clients will require changes to keep displaying up to date data. 