### PR TITLE
Better handle partial data (and formatting+)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Format with black
         uses: psf/black@stable
         with: 
-          options: "--check --verbose"
+          options: "--check --verbose -l 100"

--- a/api/data_api.py
+++ b/api/data_api.py
@@ -44,6 +44,3 @@ def samples(report: Report = Depends(), conn: Connection = Depends(get_db_conn))
     else:
         resp = {"parameters": report.dict(), "samples": results}
     return resp
-
-
-# TODO: endpoint for last_checked and last_data_update

--- a/main.py
+++ b/main.py
@@ -46,7 +46,6 @@ if __name__ == "__main__":
     configure_routing()
     uvicorn.run(app, port=8888, host="127.0.0.1")
 else:
-    # TODO: set this to prod eventually
     logger = configure_logging(env="dev")
     logger.info("> Starting application from systemd and gunicorn")
     configure_routing()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -11,7 +11,6 @@ DEFAULT_UTILITY = "Metro WW - Platte/Central"
 logger = configure_logging("dev")
 
 
-# TODO: create an override + tests to verify the status=500 code paths where the conn is bad
 def override_db_conn() -> sqlite3.Connection:
     """Use an in-memory db for API testing"""
     # load some test data into a db and table that match prod names

--- a/tools/report_app.py
+++ b/tools/report_app.py
@@ -26,9 +26,7 @@ def main():
             if utility not in utilities:
                 print(f"Invalid utility: {utility}. Please try again.")
                 break
-            lookback: str = input(
-                "Select lookback period: [3] mo, [12] mo, [a]ll time: "
-            )
+            lookback: str = input("Select lookback period: [3] mo, [12] mo, [a]ll time: ")
             end = date.today()
             match lookback:
                 case "3" | "12":
@@ -39,9 +37,7 @@ def main():
                     print(f"Invalid lookback: {lookback}")
                     break
             start = end - diff
-            param_query = (
-                f"?utility={utility}&start={start.isoformat()}&end={end.isoformat()}"
-            )
+            param_query = f"?utility={utility}&start={start.isoformat()}&end={end.isoformat()}"
             resp = requests.get(SAMPLES_PATH + param_query).json()
             cleaned_result = [data for data in resp["samples"] if data[1] is not None]
             pprint(cleaned_result)


### PR DESCRIPTION
When the source data API returns incomplete results, we'll cache the data but not update the database and corresponding API responses. The current user experience after these partial updates is bad, and (older data + good ux) seems better than (maybe newer data + bad ux). 

A better solution should come with https://github.com/jrmontag/co-covid-ww/issues/5 