### PR TITLE
Support CSV update from CDPHE download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # raw data
 *.json
 *.json.gz
+*.csv
 
 # Created by https://www.toptal.com/developers/gitignore/api/python,visualstudiocode,virtualenv
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,visualstudiocode,virtualenv

--- a/runbook.md
+++ b/runbook.md
@@ -2,14 +2,17 @@
 
 Sometimes things go awry. Better to have troubleshooting and resolution steps written down.
 
-## Data downloaded from portal is incomplete or corrupt
+## Manually update data from JSON API
 
-The new data downloads are typically ~4 MB on disk, comprising about 27,000 observations. Sometimes, 
+The new data downloads are typically ~13 MB JSON on disk, comprising about 50k observations. Sometimes, 
 the open data portal returns a truncated (but still valid JSON) response with an additional 
 `"exceededTransferLimit": true` entry. The 
 [ArcGIS docs suggest](https://resources.arcgis.com/en/help/runtime-wpf/apiref/index.html?ESRI.ArcGIS.Client~ESRI.ArcGIS.Client.FeatureLayer~ExceededTransferLimit.html) 
 that this is tripping some sort of max transfer size check. Unclear why it happens from time to 
 time, but it does.
+
+The general approach for this app is to upload the entire (new) dataset to a new `latest` table each time, 
+moving the previous version to a dated table.
 
 If an incomplete new download gets inserted into the database:
 
@@ -18,6 +21,7 @@ If an incomplete new download gets inserted into the database:
 ```bash
 sqlite-utils tables wastewater.db --table
 sqlite-utils query wastewater.db "select count(*) from latest" --table
+sqlite-utils query wastewater.db "select * from latest where SARS_COV_2_Copies_L_LP2 is not NULL order by Date desc limit 10" --table
 sqlite-utils query wastewater.db "select count(*) from '2022-12-05'" --table
 ```
 
@@ -58,6 +62,15 @@ sqlite-utils query wastewater.db "select * from 'latest' where Utility like '%Ce
 ```
 
 7. verify [the streamlit app](https://colorado-covid-wastewater.streamlit.app/) reloads correctly
+
+
+## Manually update data from CSV download
+
+CDPHE API returns JSON, but sometimes the API is just stubborn and won't return all the data for weeks on end. Or maybe they changed the way the API works. Who knows. Regardless the available CSV download seems updated, however some of the data fields are in different formats because why not.
+
+1. download csv from cdphe
+2. point update_data.py to csv (or use upload method from repl) 
+``$ python tools/update_data.py --csv data/2023-12-23_download.csv``
 
 
 

--- a/runbook.md
+++ b/runbook.md
@@ -68,9 +68,11 @@ sqlite-utils query wastewater.db "select * from 'latest' where Utility like '%Ce
 
 CDPHE API returns JSON, but sometimes the API is just stubborn and won't return all the data for weeks on end. Or maybe they changed the way the API works. Who knows. Regardless the available CSV download seems updated, however some of the data fields are in different formats because why not.
 
-1. download csv from cdphe
-2. point update_data.py to csv (or use upload method from repl) 
-``$ python tools/update_data.py --csv data/2023-12-23_download.csv``
+1. download csv from cdphe [here](https://data-cdphe.opendata.arcgis.com/datasets/cdphe-covid19-wastewater-dashboard-data/explore) to e.g. repo `data/`
+    - if appropriate, download locally and `scp` csv to vps
+2. run update script pointing to csv (or use upload method from repl) 
+``(env) $ python tools/update_data.py --csv data/2023-12-23_download.csv``
+3. restart app 
 
 
 


### PR DESCRIPTION
As mentioned in other Issues, the state's JSON API sometimes just doesn't return consistent data ¯\_(ツ)_/¯ From inspection, the CSV downloader does provide updated data, albeit with a different schema (bc why not).

This PR adds a new code path for reading, transforming, and inserting data from a local csv to the existing database. There was already a one-off method for doing this for a local JSON file. With a little refactoring, these two methods now parallel one another, are both accessible via optional `--csv` and `--json` args (with the filepath) from the command line, and leverage shared code for the DB insert. 

Since the downloaded CSV data uses a different datetime format than the JSON data (╯°□°)╯︵ ┻━┻ , the CSV reader currently transforms the dates to match those in the JSON so that we could minimize changes in this initial impl by avoiding downstream transform manipulations. This means there is currently a superfluous datetime format transformation step in the pipeline, but this code is not performance sensitive so I'm not going to lose sleep over it. 