### PR TITLE
Extend cron update functionality to try CSV update if JSON API fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 ## data files
 
 # sqlite
@@ -8,6 +7,7 @@
 *.json
 *.json.gz
 *.csv
+*.csv.gz
 
 # Created by https://www.toptal.com/developers/gitignore/api/python,visualstudiocode,virtualenv
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,visualstudiocode,virtualenv
@@ -206,4 +206,3 @@ pip-selfcheck.json
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/python,visualstudiocode,virtualenv
-


### PR DESCRIPTION
Building on https://github.com/jrmontag/co-covid-ww/pull/13, if we can programmatically download the csv without any weird data truncation than try that when the JSON API fails. 

TBD how consistent this download URL is, but it seems to work for now. Here's to more consistently updated data 🥂 