### PR TITLE
Add abstraction to better handle changing CDPHE col names

### DIFF
--- a/models/observation.py
+++ b/models/observation.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class CdpheObservation(Enum):
+    # CDPHE-defined fields
+    OBJECTID: str = "OBJECTID"
+    DATE = "Date"
+    UTILITY = "Utility"
+    COPIES_LP1 = "SARS-CoV-2 copies/L (Lab Phase 1)"
+    COPIES_LP2 = "SARS-CoV-2 copies/L (Lab Phase 2)"
+    CASES = "Number of New COVID19 Cases by Onset Date (3-Day Average)"
+    PHASE = "Lab Phase"

--- a/services/db.py
+++ b/services/db.py
@@ -16,6 +16,11 @@ SAMPLES_COLS = [CdpheObservation.COPIES_LP2.value, CdpheObservation.COPIES_LP1.v
 UTILITY_COL = CdpheObservation.UTILITY.value
 
 
+def double_quote(name: str) -> str:
+    # manually double-quote col names
+    return f'"{name}"'
+
+
 def get_connection(db_uri: str) -> sqlite3.Connection:
     conn = sqlite3.connect(db_uri, check_same_thread=False)
     # metadata table that includes tables and indexs in the db
@@ -40,7 +45,7 @@ def get_utilities(conn: sqlite3.Connection) -> List[str]:
 def get_samples(conn: sqlite3.Connection, report: Report = Depends()) -> List[str]:
     # CRUD fn for samples
     # notes on sqlite quoting and keywords: https://www.sqlite.org/lang_keywords.html
-    cols = f"{DATE_COL}, {','.join(SAMPLES_COLS)}"
+    cols = f"{DATE_COL}, {','.join([double_quote(col) for col in SAMPLES_COLS])}"
     condition = (
         f"{UTILITY_COL} = '{report.utility}' "
         + f"AND {DATE_COL} >= '{report.start}' "

--- a/services/db.py
+++ b/services/db.py
@@ -1,19 +1,19 @@
 from itertools import chain
-import json
 import logging
-from pathlib import Path
 import sqlite3
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 from fastapi import Depends
+
+from models.observation import CdpheObservation
 from models.report import Report
 
 logger = logging.getLogger(__name__)
 
 # DB conventions
 PROD_TABLE = "latest"
-DATE_COL = "Date"
-SAMPLES_COLS = ["SARS_COV_2_Copies_L_LP2", "SARS_COV_2_Copies_L_LP1"]
-UTILITY_COL = "Utility"
+DATE_COL = CdpheObservation.DATE.value
+SAMPLES_COLS = [CdpheObservation.COPIES_LP2.value, CdpheObservation.COPIES_LP1.value]
+UTILITY_COL = CdpheObservation.UTILITY.value
 
 
 def get_connection(db_uri: str) -> sqlite3.Connection:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -11,9 +11,11 @@ DEFAULT_UTILITY = "Metro WW - Platte/Central"
 
 logger = configure_logging("dev")
 
+
 def double_quote(name: str) -> str:
     # manually double-quote col names
     return f'"{name}"'
+
 
 def override_db_conn() -> sqlite3.Connection:
     """Use an in-memory db for API testing"""
@@ -37,7 +39,7 @@ def override_db_conn() -> sqlite3.Connection:
         (yesterday, DEFAULT_UTILITY, 3, 0, 0),
         (today, DEFAULT_UTILITY, 9, 0, 0),
     ]
-    
+
     test_table = "latest"
     table_and_cols = f"{test_table}({','.join([double_quote(col) for col in test_cols])})"
     table_create_stmt = f"CREATE TABLE {table_and_cols}"

--- a/tools/update_data.py
+++ b/tools/update_data.py
@@ -192,11 +192,7 @@ def fetch_portal_csv_data() -> str | None:
 def transform_raw_csv_data(csv_row: dict) -> dict:
     """Adjust the dict to match the expected schema defined in update_db."""
     # date string -> epoch ms
-    # upstream format doesn't match a python formatter without slight mod
     raw_dt = csv_row[CdpheObservation.DATE.value]
-    # mod_dt = raw_dt + "00"
-    # input_format = "%Y/%m/%d %H:%M:%S%z"
-    # dt = datetime.strptime(mod_dt, input_format)
     dt = date_parser.parse(raw_dt)
     epoch_ms = int(dt.timestamp() * 1000.0)
     csv_row[CdpheObservation.DATE.value] = epoch_ms


### PR DESCRIPTION
The data provided by CDPHE occasionally changes without warning. This time both the datetime formatting and the column names have changed. This change addresses those changes in two ways:
1. use the much more robust [dateutil parser](https://dateutil.readthedocs.io/en/stable/) instead of hard-coded formatter
2. introduce a lightweight abstraction between the raw data header and those used in the rest of this application

For (2), this change uses a simple Enum with the goal of consolidating any future field name changes into the mapping in the enumeration. These column name changes will have to be propagated to the streamlit frontend in a follow up PR. 